### PR TITLE
fix(scalingo): use bun v1.0.25

### DIFF
--- a/.scalingo/buildpack/bin/compile
+++ b/.scalingo/buildpack/bin/compile
@@ -77,7 +77,7 @@ fi
 #
 
 header "Installing bun binary"
-curl -fsSL https://bun.sh/install | bash
+curl -fsSL https://bun.sh/install | bash -s "bun-v1.0.25"
 
 #
 


### PR DESCRIPTION
<p align="center">
    <img src="https://media.giphy.com/media/obbIystETz0Xu/giphy.gif?cid=ecf05e47wpa0fjwaveq5l2pbqxzlx4w2kdnff3s1iu4zfu2f&ep=v1_gifs_search&rid=giphy.gif&ct=g">
</p>

--- 

This rollback tries to fix bun 99% CPU issues